### PR TITLE
Removed reference to batch in object switches

### DIFF
--- a/css/_vars.scss
+++ b/css/_vars.scss
@@ -47,7 +47,6 @@ $use-lozenges:      false;
 $use-rules:         false;
 $use-stats:         false;
 $use-greybox:       false;
-$use-batch:         false;
 
 
 


### PR DESCRIPTION
As batch has been removed there is no need to have a switch to toggle it on or off
