### PR TITLE
Tell sass to use UTF-8 when compiling .scss files.

### DIFF
--- a/css/watch
+++ b/css/watch
@@ -4,8 +4,8 @@
 # stylesheet to be called. Do not rename `style.scss` or alter references to it.
 
 # No minification
-#sass --watch style.scss:style.css --style expanded
+#sass -E utf-8 --watch style.scss:style.css --style expanded
 
-sass --watch style.scss:style.min.css --style compressed
+sass -E utf-8 --watch style.scss:style.min.css --style compressed
 
 exit 0


### PR DESCRIPTION
The apostrophes used in inuit-css' files are not the ASCII apostrophe, but U+05F3 encoded as UTF-8. This pull request forces sass to use the UTF-8 encoding, which should fix issue #147 in inuit-css.

Note: This could potentially break inuit.css for people who tampered with the library files and saved them as another encoding. These people should be responsible for telling sass which encoding they saved the files as.

An alternative fix is to use plain ASCII in the .scss files such that there is no need to specify an encoding to sass.
