### PR TITLE
Update _vars.scss

### DIFF
--- a/css/_vars.scss
+++ b/css/_vars.scss
@@ -2,7 +2,7 @@
     VARS.SCSS
 \*------------------------------------*/
 /**
- * Any variables you find set in inuit.css’ `_vars.scss` that you do not wish to
+ * Any variables you find set in inuit.css’ `_defaults.scss` that you do not wish to
  * keep, simply redefine here. This means that if inuit.css, for example, sets
  * your `$base-font-size` at 16px and you wish it to be 14px, simply redeclare
  * that variable in this file. inuit.css ignores its own variables in favour of


### PR DESCRIPTION
Change comment on line-5 from '_vars.scss' to '_defaults.scss'.

Current comment states: "Any variables you find set in inuit.css’ `_vars.scss` that you ...".
Change to read: "Any variables you find set in inuit.css’ `_defaults.scss` that you ...".

Explanation follows:
The core library directory inuit.css contains a file named '_defaults.scss', not the file '_vars.scss'. In fact the contents of '_vars.scss' (which we are presently reading) is intended to override '_default.scss'. This was confusing to this noobie -thanks, frannyshaw
