### PR TITLE
Fix installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Git submodule.
 
 To quickly install inuit.css, run the following commands:
 
-    $ git clone --recursive git@github.com:csswizardry/inuit.css-web-template.git your-project-folder
+    $ git clone --recursive https://github.com/csswizardry/inuit.css-web-template your-project-folder
     $ cd your-project-folder
     $ ./go
 


### PR DESCRIPTION
People propably won't have read rights on `git@github.com:csswizardry/inuit.css-web-template.git`, so we'll use `https://github.com/csswizardry/inuit.css-web-template`.

This resolves #8 and #11.
